### PR TITLE
switch to prop_dynamic

### DIFF
--- a/vscripts/user/precache.lua
+++ b/vscripts/user/precache.lua
@@ -33,7 +33,7 @@ function PrecacheResources()
 		origin = Vector(0,0,0),
 		vscripts = "ent_scripts/precache.lua"
 	}
-	ent = SpawnEntityFromTableSynchronous("prop_physics", ent_table)
+	ent = SpawnEntityFromTableSynchronous("prop_dynamic", ent_table)
 	-- Just kill it right after lol
 	ent:Kill()
 end 


### PR DESCRIPTION
prop_physics will cause weird vphysics2 bullshit to occur, whereas prop_dynamic won't simulate certain vphysics2 funcs such as realtime gravity and collision which can reduce the actual likelihood of engine2 crashing